### PR TITLE
Migrate login features to expo

### DIFF
--- a/modo-expo/app/_layout.tsx
+++ b/modo-expo/app/_layout.tsx
@@ -20,6 +20,9 @@ export default function RootLayout() {
   return (
     <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
       <Stack>
+        <Stack.Screen name="index" options={{ headerShown: false }} />
+        <Stack.Screen name="home" options={{ headerShown: false }} />
+        <Stack.Screen name="forgot" options={{ headerShown: false }} />
         <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
         <Stack.Screen name="+not-found" />
       </Stack>

--- a/modo-expo/app/forgot.tsx
+++ b/modo-expo/app/forgot.tsx
@@ -1,0 +1,60 @@
+import React, { useState } from 'react';
+import { View, TextInput, Button, Text, StyleSheet } from 'react-native';
+import { Stack, useRouter } from 'expo-router';
+import { getAuth, sendPasswordResetEmail } from 'firebase/auth';
+
+export default function ForgotPasswordScreen() {
+  const [email, setEmail] = useState('');
+  const [message, setMessage] = useState('');
+  const [isError, setIsError] = useState(false);
+  const router = useRouter();
+  const auth = getAuth();
+
+  const handleSendEmail = async () => {
+    if (!email) {
+      setMessage('Ingresá tu correo.');
+      setIsError(true);
+      return;
+    }
+    try {
+      await sendPasswordResetEmail(auth, email);
+      setMessage('Te enviamos un correo para restablecer tu contraseña.');
+      setIsError(false);
+    } catch (error) {
+      setMessage('No se pudo enviar el correo. Verificá el email.');
+      setIsError(true);
+    }
+  };
+
+  return (
+    <View style={styles.container}>
+      <Stack.Screen options={{ title: 'Recuperar contraseña' }} />
+      <TextInput
+        placeholder="Correo electrónico"
+        value={email}
+        onChangeText={setEmail}
+        style={styles.input}
+      />
+      <Button title="Enviar correo de recuperación" onPress={handleSendEmail} />
+      {!!message && (
+        <Text style={{ color: isError ? 'red' : 'green', marginTop: 10 }}>{message}</Text>
+      )}
+      <Button title="Volver al inicio" onPress={() => router.replace('/')} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    padding: 20,
+    justifyContent: 'center',
+  },
+  input: {
+    borderWidth: 1,
+    borderColor: '#ccc',
+    padding: 10,
+    marginBottom: 10,
+    borderRadius: 4,
+  },
+});

--- a/modo-expo/app/home.tsx
+++ b/modo-expo/app/home.tsx
@@ -1,0 +1,115 @@
+import React, { useEffect, useState } from 'react';
+import { View, Text, Image, Button, ActivityIndicator, StyleSheet } from 'react-native';
+import { Stack, useRouter } from 'expo-router';
+import { getAuth } from 'firebase/auth';
+import { db, storage } from '../firebase';
+import { doc, getDoc, updateDoc } from 'firebase/firestore';
+import { ref, deleteObject, uploadBytes, getDownloadURL } from 'firebase/storage';
+import * as ImagePicker from 'expo-image-picker';
+import * as ImageManipulator from 'expo-image-manipulator';
+
+export default function HomeScreen() {
+  const auth = getAuth();
+  const router = useRouter();
+  const user = auth.currentUser;
+
+  const [userData, setUserData] = useState<any>(null);
+  const [message, setMessage] = useState('');
+  const [isError, setIsError] = useState(false);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    const cargarDatos = async () => {
+      if (user) {
+        const docRef = doc(db, 'usuarios', user.uid);
+        const docSnap = await getDoc(docRef);
+        if (docSnap.exists()) {
+          setUserData(docSnap.data());
+        }
+      } else {
+        router.replace('/');
+      }
+    };
+    cargarDatos();
+  }, [user, router]);
+
+  const handleLogout = () => {
+    auth.signOut();
+    router.replace('/');
+  };
+
+  const cambiarFotoPerfil = async () => {
+    const result = await ImagePicker.launchImageLibraryAsync({
+      mediaTypes: ImagePicker.MediaTypeOptions.Images,
+      quality: 0.7,
+    });
+    if (result.canceled || !user) return;
+
+    setLoading(true);
+    try {
+      const manip = await ImageManipulator.manipulateAsync(
+        result.assets[0].uri,
+        [{ resize: { width: 800 } }],
+        { compress: 0.7 }
+      );
+      const response = await fetch(manip.uri);
+      const blob = await response.blob();
+
+      const fotoRef = ref(storage, `fotos_perfil/${user.uid}`);
+      await deleteObject(fotoRef).catch(() => {});
+      await uploadBytes(fotoRef, blob);
+      const nuevaURL = await getDownloadURL(fotoRef);
+      await updateDoc(doc(db, 'usuarios', user.uid), { fotoURL: nuevaURL });
+      setUserData((prev: any) => ({ ...prev, fotoURL: nuevaURL }));
+      setMessage('Foto de perfil actualizada con éxito.');
+      setIsError(false);
+    } catch (error) {
+      setMessage('No se pudo actualizar la foto.');
+      setIsError(true);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  if (!user || !userData) return <ActivityIndicator style={{ flex: 1 }} />;
+
+  return (
+    <View style={styles.container}>
+      <Stack.Screen options={{ title: 'Inicio' }} />
+      <Text style={styles.title}>Bienvenido, {userData.username} 👋</Text>
+      <Text>Correo: {user.email}</Text>
+      <Text>Edad: {userData.edad} años</Text>
+      {userData.fotoURL && (
+        <Image source={{ uri: userData.fotoURL }} style={styles.avatar} />
+      )}
+      <Button title="Cambiar foto" onPress={cambiarFotoPerfil} />
+      {loading && <Text style={styles.message}>Cambiando foto...</Text>}
+      {!!message && (
+        <Text style={[styles.message, { color: isError ? 'red' : 'green' }]}>{message}</Text>
+      )}
+      <Button title="Cerrar sesión" onPress={handleLogout} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    padding: 20,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  title: {
+    fontSize: 20,
+    marginBottom: 10,
+  },
+  avatar: {
+    width: 150,
+    height: 150,
+    borderRadius: 75,
+    marginVertical: 10,
+  },
+  message: {
+    marginTop: 10,
+  },
+});

--- a/modo-expo/app/index.tsx
+++ b/modo-expo/app/index.tsx
@@ -1,0 +1,156 @@
+import React, { useState } from 'react';
+import { View, Text, TextInput, Button, Image, StyleSheet, TouchableOpacity } from 'react-native';
+import { Stack } from 'expo-router';
+import { useRouter } from 'expo-router';
+import { getAuth, signInWithEmailAndPassword, createUserWithEmailAndPassword } from 'firebase/auth';
+import { doc, setDoc } from 'firebase/firestore';
+import { ref, uploadBytes, getDownloadURL } from 'firebase/storage';
+import * as ImagePicker from 'expo-image-picker';
+import * as ImageManipulator from 'expo-image-manipulator';
+import { app, db, storage } from '../firebase';
+
+const auth = getAuth(app);
+
+export default function LoginScreen() {
+  const router = useRouter();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [username, setUsername] = useState('');
+  const [edad, setEdad] = useState('');
+  const [photoUri, setPhotoUri] = useState<string | null>(null);
+  const [isRegistering, setIsRegistering] = useState(false);
+  const [message, setMessage] = useState('');
+  const [isError, setIsError] = useState(false);
+
+  const pickImage = async () => {
+    const result = await ImagePicker.launchImageLibraryAsync({
+      mediaTypes: ImagePicker.MediaTypeOptions.Images,
+      quality: 0.7,
+    });
+    if (!result.canceled) {
+      const manip = await ImageManipulator.manipulateAsync(
+        result.assets[0].uri,
+        [{ resize: { width: 800 } }],
+        { compress: 0.7 }
+      );
+      setPhotoUri(manip.uri);
+    }
+  };
+
+  const handleAuth = async () => {
+    setMessage('');
+    try {
+      if (isRegistering) {
+        if (!photoUri) {
+          setIsError(true);
+          setMessage('Seleccioná una foto de perfil.');
+          return;
+        }
+        const userCred = await createUserWithEmailAndPassword(auth, email, password);
+        const response = await fetch(photoUri);
+        const blob = await response.blob();
+        const storageRef = ref(storage, `fotos_perfil/${userCred.user.uid}`);
+        await uploadBytes(storageRef, blob);
+        const fotoURL = await getDownloadURL(storageRef);
+        await setDoc(doc(db, 'usuarios', userCred.user.uid), {
+          email,
+          username,
+          edad: parseInt(edad),
+          fotoURL,
+        });
+      } else {
+        await signInWithEmailAndPassword(auth, email, password);
+      }
+      router.replace('/home');
+    } catch (err: any) {
+      setIsError(true);
+      setMessage('Error: ' + err.message);
+    }
+  };
+
+  return (
+    <View style={styles.container}>
+      <Stack.Screen options={{ title: isRegistering ? 'Registrarse' : 'Ingresar' }} />
+      <TextInput
+        placeholder="Correo electrónico"
+        value={email}
+        onChangeText={setEmail}
+        style={styles.input}
+      />
+      <TextInput
+        placeholder="Contraseña"
+        secureTextEntry
+        value={password}
+        onChangeText={setPassword}
+        style={styles.input}
+      />
+      {isRegistering && (
+        <>
+          <TextInput
+            placeholder="Nombre de usuario"
+            value={username}
+            onChangeText={setUsername}
+            style={styles.input}
+          />
+          <TextInput
+            placeholder="Edad"
+            keyboardType="number-pad"
+            value={edad}
+            onChangeText={setEdad}
+            style={styles.input}
+          />
+          <Button title="Seleccionar foto" onPress={pickImage} />
+          {photoUri && <Image source={{ uri: photoUri }} style={styles.preview} />}
+        </>
+      )}
+      <Button title={isRegistering ? 'Crear cuenta' : 'Ingresar'} onPress={handleAuth} />
+      <TouchableOpacity
+        onPress={() => {
+          setIsRegistering(!isRegistering);
+          setMessage('');
+          setPhotoUri(null);
+        }}
+        style={styles.switch}
+      >
+        <Text>{isRegistering ? 'Inicia sesión' : 'Regístrate'}</Text>
+      </TouchableOpacity>
+      {!isRegistering && (
+        <TouchableOpacity onPress={() => router.push('/forgot')}>
+          <Text style={styles.link}>¿Olvidaste tu contraseña?</Text>
+        </TouchableOpacity>
+      )}
+      {!!message && <Text style={{ color: isError ? 'red' : 'green', marginTop: 10 }}>{message}</Text>}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    padding: 20,
+    justifyContent: 'center',
+  },
+  input: {
+    borderWidth: 1,
+    borderColor: '#ccc',
+    padding: 10,
+    marginBottom: 10,
+    borderRadius: 4,
+  },
+  preview: {
+    width: 100,
+    height: 100,
+    borderRadius: 50,
+    marginVertical: 10,
+    alignSelf: 'center',
+  },
+  switch: {
+    marginTop: 10,
+    alignItems: 'center',
+  },
+  link: {
+    marginTop: 10,
+    color: 'blue',
+    textAlign: 'center',
+  },
+});

--- a/modo-expo/firebase.ts
+++ b/modo-expo/firebase.ts
@@ -1,0 +1,18 @@
+import { initializeApp } from 'firebase/app';
+import { getFirestore } from 'firebase/firestore';
+import { getStorage } from 'firebase/storage';
+
+const firebaseConfig = {
+  apiKey: 'AIzaSyBrihqnUgeU83UfYjcF9OFF67F-1tBKVck',
+  authDomain: 'comarca-9711d.firebaseapp.com',
+  projectId: 'comarca-9711d',
+  storageBucket: 'comarca-9711d.firebasestorage.app',
+  messagingSenderId: '618590751285',
+  appId: '1:618590751285:web:42a499bb29b2ae06e83f7c',
+};
+
+const app = initializeApp(firebaseConfig);
+const db = getFirestore(app);
+const storage = getStorage(app);
+
+export { app, db, storage };

--- a/modo-expo/package.json
+++ b/modo-expo/package.json
@@ -21,6 +21,8 @@
     "expo-font": "~13.3.1",
     "expo-haptics": "~14.1.4",
     "expo-image": "~2.3.0",
+    "expo-image-manipulator": "~12.2.1",
+    "expo-image-picker": "~15.3.2",
     "expo-linking": "~7.1.5",
     "expo-router": "~5.1.0",
     "expo-splash-screen": "~0.30.9",
@@ -36,7 +38,8 @@
     "react-native-safe-area-context": "5.4.0",
     "react-native-screens": "~4.11.1",
     "react-native-web": "~0.20.0",
-    "react-native-webview": "13.13.5"
+    "react-native-webview": "13.13.5",
+    "firebase": "^11.9.1"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",


### PR DESCRIPTION
## Summary
- add firebase initialization for expo app
- create login, home and forgot password screens
- wire new routes in expo router
- include expo image picker and manipulator deps

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b5eff90cc832d9614513ae6e143ad