### PR TITLE
Implement tab-based navigation

### DIFF
--- a/celular/app/(tabs)/_layout.tsx
+++ b/celular/app/(tabs)/_layout.tsx
@@ -1,0 +1,25 @@
+import { Tabs } from 'expo-router';
+import { FontAwesome } from '@expo/vector-icons';
+
+export default function TabLayout() {
+  return (
+    <Tabs screenOptions={{ headerShown: false }}>
+      <Tabs.Screen
+        name="index"
+        options={{ title: 'Inicio', tabBarIcon: ({ color, size }) => <FontAwesome name="home" color={color} size={size} /> }}
+      />
+      <Tabs.Screen
+        name="lugares"
+        options={{ title: 'Lugares', tabBarIcon: ({ color, size }) => <FontAwesome name="map" color={color} size={size} /> }}
+      />
+      <Tabs.Screen
+        name="actividades"
+        options={{ title: 'Actividades', tabBarIcon: ({ color, size }) => <FontAwesome name="list" color={color} size={size} /> }}
+      />
+      <Tabs.Screen
+        name="perfil"
+        options={{ title: 'Perfil', tabBarIcon: ({ color, size }) => <FontAwesome name="user" color={color} size={size} /> }}
+      />
+    </Tabs>
+  );
+}

--- a/celular/app/(tabs)/actividades.tsx
+++ b/celular/app/(tabs)/actividades.tsx
@@ -1,0 +1,19 @@
+import { Stack } from 'expo-router';
+import { View, Text, StyleSheet } from 'react-native';
+
+export default function Actividades() {
+  return (
+    <View style={styles.container}>
+      <Stack.Screen options={{ title: 'Actividades' }} />
+      <Text>Pantalla de actividades</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+});

--- a/celular/app/(tabs)/index.tsx
+++ b/celular/app/(tabs)/index.tsx
@@ -1,0 +1,19 @@
+import { Stack } from 'expo-router';
+import { View, Text, StyleSheet } from 'react-native';
+
+export default function Inicio() {
+  return (
+    <View style={styles.container}>
+      <Stack.Screen options={{ title: 'Inicio' }} />
+      <Text>Pantalla de inicio</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+});

--- a/celular/app/(tabs)/lugares.tsx
+++ b/celular/app/(tabs)/lugares.tsx
@@ -1,0 +1,19 @@
+import { Stack } from 'expo-router';
+import { View, Text, StyleSheet } from 'react-native';
+
+export default function Lugares() {
+  return (
+    <View style={styles.container}>
+      <Stack.Screen options={{ title: 'Lugares' }} />
+      <Text>Pantalla de lugares</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+});

--- a/celular/app/(tabs)/perfil/index.tsx
+++ b/celular/app/(tabs)/perfil/index.tsx
@@ -5,7 +5,7 @@ import * as ImagePicker from 'expo-image-picker';
 import { getAuth } from 'firebase/auth';
 import { doc, getDoc, updateDoc } from 'firebase/firestore';
 import { ref, deleteObject, uploadBytes, getDownloadURL } from 'firebase/storage';
-import { db, storage } from '../firebase';
+import { db, storage } from '../../firebase';
 
 export default function HomeScreen() {
   const auth = getAuth();
@@ -54,7 +54,7 @@ export default function HomeScreen() {
 
   const logout = async () => {
     await auth.signOut();
-    router.replace('/login');
+    router.replace('/perfil/login');
   };
 
   if (!user || !userData) {

--- a/celular/app/(tabs)/perfil/login.tsx
+++ b/celular/app/(tabs)/perfil/login.tsx
@@ -5,7 +5,7 @@ import * as ImagePicker from 'expo-image-picker';
 import { getAuth, signInWithEmailAndPassword, createUserWithEmailAndPassword } from 'firebase/auth';
 import { doc, setDoc } from 'firebase/firestore';
 import { ref, uploadBytes, getDownloadURL } from 'firebase/storage';
-import { app, db, storage } from '../firebase';
+import { app, db, storage } from '../../firebase';
 
 export default function LoginScreen() {
   const auth = getAuth(app);
@@ -53,7 +53,7 @@ export default function LoginScreen() {
       } else {
         await signInWithEmailAndPassword(auth, email, password);
       }
-      router.replace('/home');
+      router.replace('/perfil');
     } catch (err: any) {
       setIsError(true);
       setMessage(err.message);

--- a/celular/app/+not-found.tsx
+++ b/celular/app/+not-found.tsx
@@ -10,7 +10,7 @@ export default function NotFoundScreen() {
       <Stack.Screen options={{ title: 'Oops!' }} />
       <ThemedView style={styles.container}>
         <ThemedText type="title">This screen does not exist.</ThemedText>
-        <Link href="/login" style={styles.link}>
+        <Link href="/perfil/login" style={styles.link}>
           <ThemedText type="link">Ir al inicio</ThemedText>
         </Link>
       </ThemedView>

--- a/celular/app/_layout.tsx
+++ b/celular/app/_layout.tsx
@@ -13,15 +13,13 @@ export default function RootLayout() {
   });
 
   if (!loaded) {
-    // Async font loading only occurs in development.
     return null;
   }
 
   return (
     <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
       <Stack>
-        <Stack.Screen name="login" options={{ headerShown: false }} />
-        <Stack.Screen name="home" options={{ headerShown: false }} />
+        <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
         <Stack.Screen name="forgot" options={{ title: 'Recuperar contraseña' }} />
         <Stack.Screen name="+not-found" />
       </Stack>

--- a/celular/app/forgot.tsx
+++ b/celular/app/forgot.tsx
@@ -39,7 +39,7 @@ export default function ForgotPassword() {
       {message ? (
         <Text style={{ color: isError ? 'red' : 'green', marginTop: 10 }}>{message}</Text>
       ) : null}
-      <Button title="Volver" onPress={() => router.replace('/login')} />
+      <Button title="Volver" onPress={() => router.replace('/perfil/login')} />
     </View>
   );
 }


### PR DESCRIPTION
## Summary
- move login and profile screens into `perfil` folder
- set up bottom tabs with Inicio, Lugares, Actividades and Perfil
- update routes to use `/perfil/login`

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c3ba1e984832db3be6abf77889c3a